### PR TITLE
Removed min-width of 320px and replace it with min-width: 100%

### DIFF
--- a/plugin/jw_allvideos/tmpl/Responsive/css/template.css
+++ b/plugin/jw_allvideos/tmpl/Responsive/css/template.css
@@ -22,7 +22,7 @@
 	.avVideo .avPlayerContainer .avPlayerBlock object,
 	.avVideo .avPlayerContainer .avPlayerBlock embed,
 	.avVideo .avPlayerContainer .avPlayerBlock video,
-	.avVideo .avPlayerContainer .avPlayerBlock > div {position:absolute!important;top:0;left:0;min-width:320px!important;width:100%!important;height:100%!important;}
+	.avVideo .avPlayerContainer .avPlayerBlock > div {position:absolute!important;top:0;left:0;min-width:100%!important;width:100%!important;height:100%!important;}
 	/* SoundCloud container styling only */
 	.avSoundCloudSet .avPlayerContainer .avPlayerBlock {width:100%!important;position:relative!important;padding:0 0 56% 0!important;}
 	.avSoundCloudSet .avPlayerContainer .avPlayerBlock iframe,


### PR DESCRIPTION
The miminum width of 320px will break the extension on smaller viewports because the actual available space is always less than 320px.