### PR TITLE
add facebook video embedding

### DIFF
--- a/_jw_allvideos.xml
+++ b/_jw_allvideos.xml
@@ -81,6 +81,10 @@
 					<option value="0">JW_PLG_AV_NO</option>
 					<option value="1">JW_PLG_AV_YES</option>
 				</field>
+				<field name="" type="header" default="JW_PLG_AV_FACEBOOK_PARAMETERS" label="" description="" />
+				<field name="fbAppId" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPID" description="JW_PLG_AV_FACEBOOK_APPID_DESC" />
+				<field name="fbAppSecret" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPSECRET" description="JW_PLG_AV_FACEBOOK_APPSECRET_DESC" />
+				<field name="fbsetuplink" type="spacer" label="JW_PLG_AV_FACEBOOK_APP_SETUP_LINK" />
 			</fieldset>
 		</fields>
 	</config>

--- a/jw_allvideos.xml
+++ b/jw_allvideos.xml
@@ -79,6 +79,10 @@
 			<option value="0">JW_PLG_AV_NO</option>
 			<option value="1">JW_PLG_AV_YES</option>
 		</param>
+		<param name="" type="header" default="JW_PLG_AV_FACEBOOK_PARAMETERS" label="" description="" />
+		<param name="fbAppId" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPID" description="JW_PLG_AV_FACEBOOK_APPID_DESC" />
+		<param name="fbAppSecret" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPSECRET" description="JW_PLG_AV_FACEBOOK_APPSECRET_DESC" />
+		<param name="fbsetuplink" type="spacer" label="JW_PLG_AV_FACEBOOK_APP_SETUP_LINK" />
 	</params>
 	<!-- Files -->
 	<files folder="plugin" destination="jw_allvideos">

--- a/plugin/jw_allvideos.php
+++ b/plugin/jw_allvideos.php
@@ -399,7 +399,7 @@ class plgContentJw_allvideos extends JPlugin {
 						}
 
 					}
-					
+
 					// Poster frame
 					$posterFramePath = $sitePath.DS.str_replace('/',DS,$vfolder);
 					if (JFile::exists($posterFramePath.DS.$tagsource.'.jpg')) {

--- a/plugin/jw_allvideos.xml
+++ b/plugin/jw_allvideos.xml
@@ -81,6 +81,10 @@
 					<option value="0">JW_PLG_AV_NO</option>
 					<option value="1">JW_PLG_AV_YES</option>
 				</field>
+				<field name="" type="header" default="JW_PLG_AV_FACEBOOK_PARAMETERS" label="" description="" />
+				<field name="fbAppId" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPID" description="JW_PLG_AV_FACEBOOK_APPID_DESC" />
+				<field name="fbAppSecret" type="text" default="" size="40" label="JW_PLG_AV_FACEBOOK_APPSECRET" description="JW_PLG_AV_FACEBOOK_APPSECRET_DESC" />
+				<field name="fbsetuplink" type="spacer" label="JW_PLG_AV_FACEBOOK_APP_SETUP_LINK" />
 			</fieldset>
 		</fields>
 	</config>

--- a/plugin/jw_allvideos/includes/sources.php
+++ b/plugin/jw_allvideos/includes/sources.php
@@ -630,4 +630,8 @@ $tagReplace = array(
 </object>
 ",
 
+"facebook" => $mediaplayerEmbedRemote,
+
+"facebookiframe" => "<iframe src=\"https://www.facebook.com/video/embed?video_id={SOURCE}\" width=\"{WIDTH}\" height=\"{HEIGHT}\" frameborder=\"0\" title=\"JoomlaWorks AllVideos Player\"></iframe>",
+
 );

--- a/plugin/language/en-GB/en-GB.plg_content_jw_allvideos.ini
+++ b/plugin/language/en-GB/en-GB.plg_content_jw_allvideos.ini
@@ -81,6 +81,12 @@ JW_PLG_AV_YELLOW_FFFF00="yellow (#ffff00)"
 JW_PLG_AV_YES="Yes"
 JW_PLG_AV_YT_NOCOOKIE="Enable YouTube privacy-enhanced mode"
 JW_PLG_AV_YT_NOCOOKIE_DESC="Enabling this option means that YouTube won't store information about visitors on your web page unless they play the video."
+JW_PLG_AV_FACEBOOK_PARAMETERS="Facebook Videos (Optional)"
+JW_PLG_AV_FACEBOOK_APPID="Facebook App Id"
+JW_PLG_AV_FACEBOOK_APPID_DESC="Entering your Facebook App Id will embed facebook video using html5 video player (not flash)"
+JW_PLG_AV_FACEBOOK_APPSECRET="Facebook App Secret Key"
+JW_PLG_AV_FACEBOOK_APPSECRET_DESC="Entering your Facebook App Secret Key will embed facebook video using html5 video player (not flash)"
+JW_PLG_AV_FACEBOOK_APP_SETUP_LINK="(Register your Facebook App <a href="_QQ_"https://developers.facebook.com/apps/?action=create"_QQ_" target="_QQ_"_BLANK"_QQ_">here</a>)"
 
 ; Frontend
 JW_PLG_AV_DOWNLOAD="Download"


### PR DESCRIPTION
This is NOT using [Facebook’s embedded video player](https://developers.facebook.com/docs/plugins/embedded-video-player), but using _embed_html_ code from facebook graph api.
Both uses flash, so we add option to use HTML5 videos player.

To use HTML5 video player, enter Facebook App Id and App Secret Keys in backend. (optional)
