### PR TITLE
320px is breaking the layout in older phones.

### DIFF
--- a/plugin/jw_allvideos/tmpl/Responsive/css/template.css
+++ b/plugin/jw_allvideos/tmpl/Responsive/css/template.css
@@ -27,15 +27,15 @@
 	.avSoundCloudSet .avPlayerContainer .avPlayerBlock {width:100%!important;position:relative!important;padding:0 0 56% 0!important;}
 	.avSoundCloudSet .avPlayerContainer .avPlayerBlock iframe,
 	.avSoundCloudSet .avPlayerContainer .avPlayerBlock object,
-	.avSoundCloudSet .avPlayerContainer .avPlayerBlock embed {position:absolute!important;top:0;left:0;min-width:320px!important;width:100%!important;height:100%!important;}
+	.avSoundCloudSet .avPlayerContainer .avPlayerBlock embed {position:absolute!important;top:0;left:0;min-width:100%!important;width:100%!important;height:100%!important;}
 
 	.avSoundCloudSong .avPlayerContainer .avPlayerBlock {width:100%!important;padding:0!important;}
 	.avSoundCloudSong .avPlayerContainer .avPlayerBlock iframe,
 	.avSoundCloudSong .avPlayerContainer .avPlayerBlock object,
-	.avSoundCloudSong .avPlayerContainer .avPlayerBlock embed {min-width:320px!important;width:100%!important;height:168px!important;}
+	.avSoundCloudSong .avPlayerContainer .avPlayerBlock embed {min-width:100%!important;width:100%!important;height:168px!important;}
 	/* Audio container styling only */
 	.avAudio .avPlayerContainer .avPlayerBlock {width:100%!important;padding:0!important;}
-	.avAudio .avPlayerContainer .avPlayerBlock > div {min-width:320px!important;width:100%!important;height:24px!important;}
+	.avAudio .avPlayerContainer .avPlayerBlock > div {min-width:100%!important;width:100%!important;height:24px!important;}
 
 	.avPlayerWrapper .avPlayerContainer .avPlayerBlock > div {text-align:center!important;}
 	.avPlayerWrapper .avPlayerContainer .avPlayerBlock .avDownloadLink {text-align:center;padding:4px;font-size:11px;}


### PR DESCRIPTION
The issue has been described here: http://www.joomlaworks.net/forum/allvideos/45715-videos-responsivity#155099
320px will push it outside the viewport, since the actual size is less than 320 (paddings on the side).

I am not sure about the 168px height, I will investigate and start a new PR.
