### PR TITLE
Midway Commit: Removed the id from the audio template

### DIFF
--- a/plugin/jw_allvideos/includes/sources.php
+++ b/plugin/jw_allvideos/includes/sources.php
@@ -44,7 +44,7 @@ $mediaplayerEmbedRemote = "
 
 /* -------------------------------- Embed templates for AUDIO -------------------------------- */
 $audioPlayerEmbed = "
-<div id=\"avID_{SOURCEID}\" style=\"width:{WIDTH}px;height:{HEIGHT}px;\" title=\"JoomlaWorks AllVideos Player\"></div>
+<div style=\"width:{WIDTH}px;height:{HEIGHT}px;\" title=\"JoomlaWorks AllVideos Player\"></div>
 <script type=\"text/javascript\">
 	jwplayer('avID_{SOURCEID}').setup({
 		'file': '{SITEURL}/{FOLDER}/{SOURCE}.{FILE_EXT}',
@@ -59,7 +59,7 @@ $audioPlayerEmbed = "
 ";
 
 $audioPlayerEmbedRemote = "
-<div id=\"avID_{SOURCEID}\" style=\"width:{WIDTH}px;height:{HEIGHT}px;\" title=\"JoomlaWorks AllVideos Player\"></div>
+<div style=\"width:{WIDTH}px;height:{HEIGHT}px;\" title=\"JoomlaWorks AllVideos Player\"></div>
 <script type=\"text/javascript\">
 	jwplayer('avID_{SOURCEID}').setup({
 		'file': '{SOURCE}',


### PR DESCRIPTION
The ID is already present in the template and it can break JWPlayer.
Will try with other local sources as well.